### PR TITLE
Shard sim-reference benchmark by replicate chunk to fit GHA ceiling

### DIFF
--- a/.github/workflows/sim-reference-benchmark.yml
+++ b/.github/workflows/sim-reference-benchmark.yml
@@ -2,13 +2,17 @@
 #
 # Generates the four reference simulated datasets (sim_ideal / sim_typical
 # / sim_heterogeneous / sim_hard) once, then evaluates BACE on every
-# replicate in parallel matrix jobs (one job per dataset), and aggregates
-# the per-rep results into a cross-dataset summary.
+# replicate in parallel matrix jobs, and aggregates the per-rep results
+# into a cross-dataset summary.
 #
-# Each dataset has 30-50 replicates. The evaluator runs at production
-# MCMC budget (nitt=50000, burnin=10000, thin=25, runs=10, n_final=50).
-# With 4 inner cores per runner, every matrix job fits within the 6h GHA
-# timeout (largest expected: sim_heterogeneous, ~3.8h).
+# Sharding: the matrix is built dynamically in the `prepare` job, one job
+# per small CONTIGUOUS CHUNK of replicates (chunk_size, default 4) rather
+# than one job per whole dataset. With 30-50 reps/dataset that previously
+# meant a single 4-vCPU runner had to grind through every rep at full MCMC
+# budget within the 6h GitHub ceiling — which it cannot, so every
+# dataset-level job timed out. Per-chunk jobs each finish in well under an
+# hour, and GitHub runs ~20 of them concurrently, so the whole production
+# sweep completes in a few hours of wallclock with no job near the ceiling.
 #
 # Trigger: Actions tab -> "Simulated reference benchmark" -> Run workflow.
 
@@ -18,26 +22,34 @@ on:
   workflow_dispatch:
     inputs:
       mode:
-        description: "smoke = 1 rep/dataset at tiny MCMC budget (~15 min, validates pipeline); production = all reps at full budget (~4h per matrix job)."
+        description: "smoke = 1 rep/dataset at tiny MCMC budget (~15 min, validates pipeline); production = all reps at full budget."
         type: choice
         options:
           - smoke
           - production
         default: smoke
+      chunk_size:
+        description: "Replicates per matrix job in production mode. Smaller = safer against the 6h ceiling but more jobs."
+        type: string
+        default: "4"
 
 jobs:
   # ---------------------------------------------------------------------
-  # 1. Generate the four reference datasets (~5 min total). Uploaded as
-  #    a shared artifact so the matrix evaluator jobs don't each redo it.
+  # 1. Generate the four reference datasets (~5 min total) and build the
+  #    per-chunk evaluate matrix. Datasets are uploaded as a shared
+  #    artifact so the evaluator jobs don't each redo generation.
   # ---------------------------------------------------------------------
   prepare:
-    name: Generate reference datasets
+    name: Generate datasets + build matrix
     runs-on: ubuntu-latest
     timeout-minutes: 30
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       R_KEEP_PKG_SOURCE: yes
+
+    outputs:
+      matrix: ${{ steps.setmatrix.outputs.matrix }}
 
     steps:
       - uses: actions/checkout@v4
@@ -55,6 +67,10 @@ jobs:
       - name: Generate datasets
         run: Rscript dev/09_generate_reference_datasets.R
 
+      - name: Build evaluate matrix
+        id: setmatrix
+        run: Rscript dev/_build_eval_matrix.R "${{ inputs.mode }}" "${{ inputs.chunk_size }}"
+
       - name: Upload reference-dataset artifact
         uses: actions/upload-artifact@v4
         with:
@@ -63,27 +79,25 @@ jobs:
           if-no-files-found: error
 
   # ---------------------------------------------------------------------
-  # 2. Evaluate BACE on every replicate. One matrix job per dataset; each
-  #    job parallelises across replicates internally with mclapply.
+  # 2. Evaluate BACE on each chunk of replicates. One matrix job per
+  #    {dataset, start, end} chunk emitted by the prepare job.
   # ---------------------------------------------------------------------
   evaluate:
-    name: ${{ matrix.dataset }}
+    name: ${{ matrix.dataset }} reps ${{ matrix.start }}-${{ matrix.end }}
     needs: prepare
     runs-on: ubuntu-latest
-    timeout-minutes: 345  # 5h45m, under 6h GHA ceiling
+    timeout-minutes: 180  # generous safety net; per-chunk jobs run minutes-to-~1h
     strategy:
       fail-fast: false
-      matrix:
-        dataset: [sim_ideal, sim_typical, sim_heterogeneous, sim_hard]
+      matrix: ${{ fromJSON(needs.prepare.outputs.matrix) }}
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       R_KEEP_PKG_SOURCE: yes
       BACE_EVAL_CORES: 4  # ubuntu-latest is 4 vCPU as of 2025-Q1
       # MCMC budget — toggled by the `mode` workflow input. Smoke values
-      # exercise every code path (generate -> matrix -> aggregate -> report)
-      # in a few minutes per matrix job; production values match the
-      # defaults baked into dev/10_evaluate_reference_datasets.R.
+      # exercise every code path in a few minutes; production values match
+      # the defaults baked into dev/10_evaluate_reference_datasets.R.
       BACE_NITT:    ${{ inputs.mode == 'smoke' && '2000' || '50000' }}
       BACE_BURNIN:  ${{ inputs.mode == 'smoke' && '500'  || '10000' }}
       BACE_THIN:    ${{ inputs.mode == 'smoke' && '5'    || '25' }}
@@ -109,27 +123,22 @@ jobs:
           name: reference-datasets
           path: dev/simulation_results/reference_datasets/
 
-      - name: Evaluate BACE on ${{ matrix.dataset }}
-        # Shell-level heartbeat to keep the runner's watchdog happy
-        # during long stretches when parallel R workers go quiet
-        # (mclapply children don't stream stdout to the parent).
-        # In smoke mode we pass `1` as the second CLI arg so the evaluator
-        # runs only rep 1 of each dataset (see CLI block in 10_*.R).
+      - name: Evaluate BACE on ${{ matrix.dataset }} reps ${{ matrix.start }}-${{ matrix.end }}
+        # Shell-level heartbeat to keep the runner's watchdog happy during
+        # long stretches when parallel R workers go quiet (mclapply children
+        # don't stream stdout to the parent).
         run: |
-          (while sleep 60; do echo "[heartbeat $(date -u +%H:%M:%S)] still evaluating ${{ matrix.dataset }} (mode=${{ inputs.mode }})"; done) &
+          (while sleep 60; do echo "[heartbeat $(date -u +%H:%M:%S)] still evaluating ${{ matrix.dataset }} reps ${{ matrix.start }}-${{ matrix.end }} (mode=${{ inputs.mode }})"; done) &
           HEARTBEAT_PID=$!
           trap 'kill $HEARTBEAT_PID 2>/dev/null || true' EXIT
-          if [ "${{ inputs.mode }}" = "smoke" ]; then
-            Rscript dev/10_evaluate_reference_datasets.R ${{ matrix.dataset }} 1
-          else
-            Rscript dev/10_evaluate_reference_datasets.R ${{ matrix.dataset }}
-          fi
+          Rscript dev/10_evaluate_reference_datasets.R \
+            "${{ matrix.dataset }}" "${{ matrix.start }}" "${{ matrix.end }}"
 
-      - name: Upload per-dataset evaluation artifact
+      - name: Upload per-chunk evaluation artifact
         if: always()  # capture partial output on timeout/failure
         uses: actions/upload-artifact@v4
         with:
-          name: eval-${{ matrix.dataset }}
+          name: eval-${{ matrix.dataset }}-${{ matrix.start }}-${{ matrix.end }}
           path: dev/simulation_results/evaluation_results/${{ matrix.dataset }}/
           if-no-files-found: warn
 
@@ -161,19 +170,30 @@ jobs:
       - name: Download all evaluation artifacts
         uses: actions/download-artifact@v4
         with:
-          path: dev/simulation_results/evaluation_results
+          path: dev/simulation_results/_chunks
           pattern: eval-*
 
-      - name: Move artifact dirs into expected layout
-        # download-artifact unpacks each artifact into a directory named
-        # after the artifact (eval-sim_ideal/...). Rename to the dataset
-        # names the aggregator expects.
+      - name: Flatten per-chunk artifacts into per-dataset layout
+        # Each artifact unpacks to a dir named eval-<dataset>-<start>-<end>.
+        # The aggregator expects evaluation_results/<dataset>/eval_rep_NN.rds,
+        # so strip the eval- prefix and -start-end suffix and merge the
+        # per-rep RDS files (rep ids are unique within a dataset, so chunks
+        # never collide).
         run: |
-          cd dev/simulation_results/evaluation_results
-          for d in eval-*; do
-            mv "$d" "${d#eval-}"
-          done
-          ls -la
+          set -euo pipefail
+          src=dev/simulation_results/_chunks
+          dst=dev/simulation_results/evaluation_results
+          mkdir -p "$dst"
+          if [ -d "$src" ]; then
+            for d in "$src"/eval-*; do
+              [ -d "$d" ] || continue
+              base=$(basename "$d")
+              dataset=$(echo "$base" | sed -E 's/^eval-(.+)-[0-9]+-[0-9]+$/\1/')
+              mkdir -p "$dst/$dataset"
+              cp -n "$d"/eval_rep_*.rds "$dst/$dataset/" 2>/dev/null || true
+            done
+          fi
+          echo "Flattened layout:"; ls -R "$dst" || true
 
       - name: Aggregate
         run: Rscript dev/11_aggregate_reference_evaluations.R

--- a/dev/10_evaluate_reference_datasets.R
+++ b/dev/10_evaluate_reference_datasets.R
@@ -312,20 +312,40 @@ build_worklist <- function() {
 
 # CLI:
 #   Rscript dev/10_*.R                    # all reps, all datasets
-#   Rscript dev/10_*.R sim_hard           # all reps of sim_hard (CI uses this)
+#   Rscript dev/10_*.R sim_hard           # all reps of sim_hard
 #   Rscript dev/10_*.R sim_hard 1         # one rep, smoke test
+#   Rscript dev/10_*.R sim_hard 5 12      # reps 5..12 (CI shards by rep range)
+#
+# The 3-arg rep-range form is what the GitHub Actions matrix uses: each job
+# evaluates a small contiguous chunk of reps so it finishes well under the
+# 6h hosted-runner ceiling. Requested reps are intersected with the reps
+# that actually exist on disk, so an over-broad end bound is harmless.
 args <- commandArgs(trailingOnly = TRUE)
-if (length(args) == 2L) {
+
+avail_reps <- function(ds) {
+  reps <- list.files(file.path(REF_ROOT, ds), pattern = "^rep_\\d+\\.rds$")
+  if (length(reps) == 0L) stop("No reps found for dataset: ", ds)
+  sort(as.integer(sub("^rep_(\\d+)\\.rds$", "\\1", reps)))
+}
+
+if (length(args) == 3L) {
+  ds        <- args[[1]]
+  start_rep <- as.integer(args[[2]])
+  end_rep   <- as.integer(args[[3]])
+  if (is.na(start_rep) || is.na(end_rep) || start_rep > end_rep)
+    stop("Invalid rep range: ", args[[2]], " ", args[[3]])
+  rep_ids <- intersect(start_rep:end_rep, avail_reps(ds))
+  if (length(rep_ids) == 0L)
+    stop("No existing reps in range ", start_rep, "-", end_rep,
+         " for dataset: ", ds)
+  worklist <- data.frame(dataset = ds, rep_id = rep_ids,
+                         stringsAsFactors = FALSE)
+} else if (length(args) == 2L) {
   worklist <- data.frame(dataset = args[[1]],
                          rep_id  = as.integer(args[[2]]),
                          stringsAsFactors = FALSE)
 } else if (length(args) == 1L) {
-  reps <- list.files(file.path(REF_ROOT, args[[1]]),
-                     pattern = "^rep_\\d+\\.rds$")
-  if (length(reps) == 0L)
-    stop("No reps found for dataset: ", args[[1]])
-  rep_ids <- sort(as.integer(sub("^rep_(\\d+)\\.rds$", "\\1", reps)))
-  worklist <- data.frame(dataset = args[[1]], rep_id = rep_ids,
+  worklist <- data.frame(dataset = args[[1]], rep_id = avail_reps(args[[1]]),
                          stringsAsFactors = FALSE)
 } else {
   worklist <- build_worklist()

--- a/dev/_build_eval_matrix.R
+++ b/dev/_build_eval_matrix.R
@@ -1,0 +1,72 @@
+# =============================================================================
+# _build_eval_matrix.R
+#
+# Emit the GitHub Actions `evaluate` matrix as JSON, sharding each reference
+# dataset's replicates into small contiguous chunks so every matrix job
+# finishes well under the 6h hosted-runner ceiling.
+#
+# Usage (from the workflow `prepare` job, AFTER datasets are generated):
+#   Rscript dev/_build_eval_matrix.R <mode> <chunk_size>
+#     mode       : "smoke" (1 rep/dataset) or "production" (all reps, chunked)
+#     chunk_size : reps per matrix job in production mode (default 4)
+#
+# Writes a line `matrix=<json>` to $GITHUB_OUTPUT (or stdout when run
+# locally), where <json> is {"include":[{dataset,start,end}, ...]} suitable
+# for `strategy.matrix: ${{ fromJSON(needs.prepare.outputs.matrix) }}`.
+# =============================================================================
+
+REF_ROOT <- file.path("dev", "simulation_results", "reference_datasets")
+DATASETS <- c("sim_ideal", "sim_typical", "sim_heterogeneous", "sim_hard")
+
+args       <- commandArgs(trailingOnly = TRUE)
+mode       <- if (length(args) >= 1L && nzchar(args[[1]])) args[[1]] else "production"
+chunk_size <- if (length(args) >= 2L && nzchar(args[[2]])) as.integer(args[[2]]) else 4L
+if (is.na(chunk_size) || chunk_size < 1L) chunk_size <- 4L
+
+avail_reps <- function(ds) {
+  d <- file.path(REF_ROOT, ds)
+  if (!dir.exists(d)) return(integer(0))
+  reps <- list.files(d, pattern = "^rep_\\d+\\.rds$")
+  sort(as.integer(sub("^rep_(\\d+)\\.rds$", "\\1", reps)))
+}
+
+# Build {dataset,start,end} chunks ------------------------------------------
+entries <- list()
+add_entry <- function(ds, start, end) {
+  entries[[length(entries) + 1L]] <<- sprintf(
+    '{"dataset":"%s","start":%d,"end":%d}', ds, start, end)
+}
+
+for (ds in DATASETS) {
+  reps <- avail_reps(ds)
+  if (length(reps) == 0L) next
+
+  if (identical(mode, "smoke")) {
+    # One rep per dataset — mirrors the previous smoke behaviour (rep 1).
+    add_entry(ds, reps[[1]], reps[[1]])
+    next
+  }
+
+  # Production: contiguous chunks over the actual rep ids present on disk.
+  starts <- seq(1L, length(reps), by = chunk_size)
+  for (s in starts) {
+    e <- min(s + chunk_size - 1L, length(reps))
+    add_entry(ds, reps[[s]], reps[[e]])
+  }
+}
+
+if (length(entries) == 0L)
+  stop("No reference-dataset reps found under ", REF_ROOT,
+       " — did dev/09_generate_reference_datasets.R run first?")
+
+json <- paste0('{"include":[', paste(unlist(entries), collapse = ","), "]}")
+
+# Emit ----------------------------------------------------------------------
+gho <- Sys.getenv("GITHUB_OUTPUT", unset = "")
+line <- paste0("matrix=", json)
+if (nzchar(gho)) {
+  cat(line, "\n", file = gho, sep = "", append = TRUE)
+}
+cat("mode=", mode, " chunk_size=", chunk_size,
+    " jobs=", length(entries), "\n", sep = "")
+cat(line, "\n", sep = "")


### PR DESCRIPTION
The production sim-reference benchmark sharded its matrix by dataset (4 jobs), forcing a single 4-vCPU runner to evaluate 30-50 reps at full MCMC budget within the 6h hosted-runner ceiling. It cannot: in the last production run all four matrix jobs hit the 5h45m timeout and were cancelled, two before even uploading partial artifacts.

Re-shard by small contiguous replicate chunks instead:

- dev/_build_eval_matrix.R (new): emits the evaluate matrix as JSON ({dataset,start,end} per chunk) from the reps actually generated; chunk_size configurable, smoke mode yields one rep per dataset.
- dev/10_evaluate_reference_datasets.R: add a 3-arg 'dataset start end' rep-range CLI form (intersected with reps present on disk); existing 1-arg and 2-arg forms unchanged.
- sim-reference-benchmark.yml: prepare job builds the matrix dynamically and exposes it as an output; evaluate job fans out one job per chunk (~47 small jobs at chunk_size=4, ~20 run concurrently, each well under an hour); aggregate flattens per-chunk artifacts back into the per-dataset layout the aggregator expects. Adds a chunk_size workflow input and lowers the per-job timeout to a 3h safety net.

No package code touched; dev/ and .github/ are Rbuildignored.